### PR TITLE
bug #8: passing alternatives as input

### DIFF
--- a/project/[[python_package_import_name]]/dev/prepare.py.jinja
+++ b/project/[[python_package_import_name]]/dev/prepare.py.jinja
@@ -28,7 +28,7 @@ def preprocess(df):
             ' your data column should have {"alternatives": [[{"transcript": "..."}]]})'
             f' \ninstead looks like {data}')
         data = merge_asr_output(data)
-        texts.append(data)
+        texts.append(alternatives)
         [% endif %]
         [% if intent_classification_flavor == 2 %]
         texts.append(row[const.DATA])


### PR DESCRIPTION
resolves #8, theoretically.

yet to figure out if the copier template will reflect this. since copier didn't reflect any changes we made to the template last time.

tried creating a dummy project called `blue` using

```bash
copier copy dialogy-template-simple-transformers ./blue
```

but the update in `prepare.py.jinja` from `data` to `alternatives` isn't getting reflected.