### PR TITLE
bug #9: use triple quotes instead

### DIFF
--- a/project/[[python_package_import_name]]/dev/prepare.py.jinja
+++ b/project/[[python_package_import_name]]/dev/prepare.py.jinja
@@ -25,7 +25,7 @@ def preprocess(df):
             alternatives = data[const.ALTERNATIVES]
         except KeyError as key_error:
             raise KeyError('Your data doesn\'t match the expected format!'
-            ' your data column should have {"alternatives": [[{"transcript": "..."}]]})'
+            """ your data column should have {"alternatives": [[{"transcript": "..."}]]})"""
             f' \ninstead looks like {data}')
         data = merge_asr_output(data)
         texts.append(data)


### PR DESCRIPTION
resolves #9 , theoretically again.

yet to figure out if the copier template will reflect this. since copier didn't reflect any changes we made to the template last time.

tried creating a dummy project called `yellow` using

```bash
copier copy dialogy-template-simple-transformers ./yellow
```

but the update in `prepare.py.jinja` from `'` to `"""` isn't getting reflected. 😿 